### PR TITLE
Module declaration

### DIFF
--- a/lexer.sml
+++ b/lexer.sml
@@ -16,6 +16,7 @@ structure Lexer :> LEXER = struct
     | ANNOTATION
     | COMMA
     | MODULE_BEGIN
+    | DOT
     | CONSTANT
     | STRING_LITERAL of string
 
@@ -72,6 +73,7 @@ structure Lexer :> LEXER = struct
     | tokenToString ANNOTATION = "@ (annotation)"
     | tokenToString COMMA = "{comma ','}"
     | tokenToString LAMBDA_BAR = "|"
+    | tokenToString DOT = "."
     | tokenToString (STRING_LITERAL s) = ("\"" ^ s ^ "\"")
     | tokenToString label =
         (case getLabelString label of
@@ -89,7 +91,7 @@ structure Lexer :> LEXER = struct
   fun member list elem = List.exists (fn x => x = elem) list
 
   val opChars = [#"+", #"-", #"/", #"*", #"$", #"<", #">",
-                 #"=", #".", #":", #"~", #"^"]
+                 #"=", #":", #"~", #"^"]
 
   fun peekChar [] = NONE
     | peekChar (c::cs) = SOME c
@@ -180,6 +182,10 @@ structure Lexer :> LEXER = struct
       (* COMMA LEXING *)
       else if c = #"," then
         ((COMMA, r), getNewLexer(cs, r))
+
+      (* MODULE REFERENCE LEXING *)
+      else if c = #"." then
+        ((DOT, r), getNewLexer(cs, r))
 
       (* STRING LEXING *)
       else if c = #"\"" then

--- a/lexerSig.sml
+++ b/lexerSig.sml
@@ -16,6 +16,7 @@ signature LEXER = sig
     | ANNOTATION
     | COMMA
     | MODULE_BEGIN
+    | DOT
     | CONSTANT
     | STRING_LITERAL of string
 

--- a/main.sml
+++ b/main.sml
@@ -51,7 +51,7 @@ let
   val opMap = Parser.addNewOperators(Parser.newOperatorMap, operators)
   val inputChars = getInputChars fileName
   val tokens = buildTokens inputChars builtInOpStrs fileName
-  val parseForest = Parser.parse(tokens, opMap, fileName)
+  val (moduleName, parseForest) = Parser.parse(tokens, opMap, fileName)
 in Utils.exit Utils.SUCCESS
 end
 

--- a/parser.sml
+++ b/parser.sml
@@ -303,30 +303,45 @@ structure Parser :> PARSER = struct
 
   val parseFunction : (Lexer.token list * operatorMap * bool * string) -> (definition * Lexer.token list) = parseFunction
 
-  fun parse([], _, _) = []
-    | parse(t::ts, opMap, fileName) = (case getLabel t of
-          Lexer.IMPURE => (case ts of
-             [] => raiseError("Got \"impure\" keyword without function definition", getLine t, fileName)
-           | ((Lexer.FUNCTION_START, line)::ts') =>
-               let
-                 val (func, funcState) = parseFunction(ts', opMap, false, fileName)
-               in
-                 (TOP_DEFINE(func, getLine t)) :: parse(funcState, opMap, fileName)
-               end
-           | (t'::ts') => raiseError("Got \"impure\" keyword without function definition", getLine t, fileName))
-        | Lexer.FUNCTION_START =>
-               let
-                 val (func, funcState) = parseFunction(ts, opMap, true, fileName)
-               in
-                 (TOP_DEFINE(func, getLine t)) :: parse(funcState, opMap, fileName)
-               end
-        | Lexer.CONSTANT =>
-            let
-              val (exprOpt, exprState) = parseExpression(ts, opMap, MIN_OP_PRECEDENCE, fileName, true)
-              val exp = lazyGetOpt(exprOpt, fn () => raiseError("Unexpected error getting constant expression", getLine t, fileName))
-            in
-              (CONSTANT(exp, getLine t)) :: parse(exprState, opMap, fileName)
-            end
-        | label =>
-            raiseError("Expected function definition or constant definition, got " ^ (Lexer.tokenToString label), getLine t, fileName))
+  fun parse([], _, fileName) =
+        raiseError("Empty file", ~1, fileName)
+    | parse((Lexer.MODULE_BEGIN, line1)::
+            (Lexer.IDENTIFIER moduleName, line2)::ts,
+            opMap,
+            fileName) =
+      let
+        fun innerParse [] =
+              raiseError("Module ended without \"" ^ (Lexer.tokenToString Lexer.BLOCK_END) ^ "\" keyword", ~1, fileName)
+          | innerParse [(Lexer.BLOCK_END, endLine)] = []
+          | innerParse (t::ts) = (case getLabel t of
+              Lexer.IMPURE => (case ts of
+                 [] => raiseError("Got \"impure\" keyword without function definition", getLine t, fileName)
+               | ((Lexer.FUNCTION_START, line)::ts') =>
+                   let
+                     val (func, funcState) = parseFunction(ts', opMap, false, fileName)
+                   in
+                     (TOP_DEFINE(func, getLine t)) :: innerParse(funcState)
+                   end
+               | (t'::ts') => raiseError("Got \"impure\" keyword without function definition", getLine t, fileName))
+            | Lexer.FUNCTION_START =>
+                   let
+                     val (func, funcState) = parseFunction(ts, opMap, true, fileName)
+                   in
+                     (TOP_DEFINE(func, getLine t)) :: innerParse(funcState)
+                   end
+            | Lexer.CONSTANT =>
+                let
+                  val (exprOpt, exprState) = parseExpression(ts, opMap, MIN_OP_PRECEDENCE, fileName, true)
+                  val exp = lazyGetOpt(exprOpt, fn () => raiseError("Unexpected error getting constant expression", getLine t, fileName))
+                in
+                  (CONSTANT(exp, getLine t)) :: innerParse(exprState)
+                end
+            | label =>
+                raiseError("Expected function definition or constant definition, got " ^ (Lexer.tokenToString label), getLine t, fileName))
+      in (moduleName, innerParse ts)
+      end
+    | parse(t::ts, _, fileName) =
+        raiseError("Syntax error at start of module (expected " ^
+          (Lexer.tokenToString Lexer.MODULE_BEGIN) ^ " {module name})",
+          getLine t, fileName)
 end

--- a/parserSig.sml
+++ b/parserSig.sml
@@ -24,7 +24,8 @@ signature PARSER = sig
 
   type module
 
-  val parse : (Lexer.token list * operatorMap * string) -> topLevel list
+  (* returns module name and AST forest *)
+  val parse : (Lexer.token list * operatorMap * string) -> (string * (topLevel list))
 
   val newOperatorMap : operatorMap
 

--- a/parserSig.sml
+++ b/parserSig.sml
@@ -13,6 +13,8 @@ signature PARSER = sig
                | LIT of value * int
                | VAR of identifier * int
                | CALL of exp * exp list * int
+               | MODULE_CALL of string * string * exp list * int
+               | MODULE_VAR of string * string * int
                | LAMBDA of identifier list * exp
 
   datatype topLevel = TOP_DEFINE of definition * int


### PR DESCRIPTION
First set of changes towards handling modules

Handle `foo.bar`, `module foo`, and `foo.bar(x, y)` constructs
