### PR TITLE
Add support for adding user-defined operators at parse time

### DIFF
--- a/lexerSig.sml
+++ b/lexerSig.sml
@@ -18,6 +18,8 @@ signature LEXER = sig
     | MODULE_BEGIN
     | DOT
     | CONSTANT
+    | INFIX
+    | INFIXR
     | STRING_LITERAL of string
 
   type line = int

--- a/utils.sml
+++ b/utils.sml
@@ -43,4 +43,5 @@ structure Utils = struct
         ((printAndFail o errorWithFileLine) (module, fileName, line)))
   end
 
+  fun member list elem = List.exists (fn x => x = elem) list
 end


### PR DESCRIPTION
Adding the `infix` and `infixr` keywords to declare operators

In the form of `infix[r] {int} {operator}` like SML

Will still need to work on parsing operator definitions
