### PR TITLE
Adding lexer recognition of identifiers reserved for internal codegen use

### DIFF
--- a/lexer.sml
+++ b/lexer.sml
@@ -240,8 +240,11 @@ structure Lexer :> LEXER = struct
         in
           if (Utils.member builtInOperators result) then
             ((OPERATOR result, r), restOfLexer)
-           else
-             ((IDENTIFIER result, r), restOfLexer)
+          else if String.isPrefix Utils.RESERVED_PREFIX result then
+            Utils.error(Utils.LEXER(fileName, r), "Identifiers beginning with '" ^
+              Utils.RESERVED_PREFIX ^ "' are reserved for internal use")
+          else
+            ((IDENTIFIER result, r), restOfLexer)
         end
 
       (* ANNOTATION LEXING *)

--- a/utils.sml
+++ b/utils.sml
@@ -3,6 +3,8 @@ structure Utils = struct
 
   val github = "github.com/GrahamGoudeau/Gamma-Lang"
 
+  val RESERVED_PREFIX = "___"
+
   fun printLn s = print (s ^ "\n")
 
   fun unexpectedError message =


### PR DESCRIPTION
closes #27 
